### PR TITLE
Fix cmpBuf bug and path computation for extension nodes

### DIFF
--- a/assembly/main.ts
+++ b/assembly/main.ts
@@ -242,6 +242,7 @@ function verifyMultiproofAndUpdate(
         if (leafIdx >= leafKeys.length) {
           throw new Error('Not enough leaves in multiproof')
         }
+
         let path = removeHexPrefix(uintArrToNibbleArr(leafKeys[leafIdx].buffer))
         paths[leafIdx] = path
         let l = encodeLeaf(leafKeys[leafIdx].buffer, accounts[leafIdx].buffer)
@@ -294,6 +295,8 @@ function verifyMultiproofAndUpdate(
         }
 
         let key = nibbleArrToUintArr(addHexPrefix(nibbles, false))
+        // addHexPrefix modifies array in-place
+        nibbles = removeHexPrefix(nibbles)
         let h = hashExtension(key, childHash)
         let nh = hashExtension(key, newChildHash)
 

--- a/assembly/util.ts
+++ b/assembly/util.ts
@@ -32,7 +32,7 @@ export function cmpBuf(buf: Uint8Array, other: Uint8Array): usize {
   // Assume Big-endian
   for (let i = 0; i < buf.length; i++) {
     let a = buf[i]
-    let b = buf[i]
+    let b = other[i]
     if (a == b) {
       continue
     } else if (a < b) {

--- a/assembly/util.ts
+++ b/assembly/util.ts
@@ -132,3 +132,13 @@ export function nibbleArrToUintArr(arr: Array<u8>): Uint8Array {
 
   return buf;
 }
+
+export function u8ArrToUintArr(arr: Array<u8>): Uint8Array {
+  let buf = new Uint8Array(arr.length)
+
+  for (let i = 0; i < arr.length; i++) {
+    buf[i] = arr[i]
+  }
+
+  return buf
+}


### PR DESCRIPTION
This PR:

- Fixes #16
- That led to finding a bug when re-computing paths, which were caused by `addHexPrefix` modifying arrays in-place. This caused the hex prefix being appended to paths that contained an extension node
- Also added a util function to convert `Array<u8>` to `Uint8Array`