### PR TITLE
Use package.json for cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@
      steps:
        - checkout
        - restore_cache:
-           key: dependency-cache-{{ checksum "package-lock.json" }}
+           key: dependency-cache-{{ checksum "package.json" }}
        - run:
            name: Install dependencies
            command: npm install
        - save_cache:
-           key: dependency-cache-{{ checksum "package-lock.json" }}
+           key: dependency-cache-{{ checksum "package.json" }}
            paths:
              - node_modules
        - run:


### PR DESCRIPTION
CI wasn't able to cache dependencies because we haven't checked `package-lock.json` in the repo. Instead detect changes based on checksum of `package.json`.