### PR TITLE
Drop ADD opcode in favor of encompassing BRANCH

### DIFF
--- a/assembly/main.ts
+++ b/assembly/main.ts
@@ -217,9 +217,7 @@ class StackItem {
     public kind: NodeType,
     public pathIndices: Array<usize>,
     public hash: Uint8Array | null,
-    public sponge: Array<Uint8Array | null> | null,
     public newHash: Uint8Array | null,
-    public newSponge: Array<Uint8Array | null> | null,
   ) {}
 
 }
@@ -253,7 +251,7 @@ function verifyMultiproofAndUpdate(
           throw new Error('Not enough hashes in multiproof')
         }
         let h = hashes[hashIdx++].buffer
-        stack[stackTop++] = new StackItem(NodeType.Hash, [], h, null, h, null)
+        stack[stackTop++] = new StackItem(NodeType.Hash, [], h, h)
         break
     case Opcode.Leaf:
         if (leafIdx >= leafKeys.length) {
@@ -267,7 +265,7 @@ function verifyMultiproofAndUpdate(
         leafIdx++
         let h = hash(l)
         let nh = hash(ul)
-        stack[stackTop++] = new StackItem(NodeType.Leaf, [leafIdx - 1], h, null, nh, null)
+        stack[stackTop++] = new StackItem(NodeType.Leaf, [leafIdx - 1], h, nh)
         break
     case Opcode.Branch:
         let indicesLen = instructions[pc++]
@@ -283,25 +281,19 @@ function verifyMultiproofAndUpdate(
         for (let i = 0; i < branchIndices.length; i++) {
           let idx = branchIndices[i]
           let n = stack[--stackTop]
-          let ch: Uint8Array
-          let nch: Uint8Array
-          if (n.kind == NodeType.Branch) {
-            ch = hashBranch(n.sponge as Array<Uint8Array | null>)
-            nch = hashBranch(n.newSponge as Array<Uint8Array | null>)
-          } else {
-            ch = n.hash as Uint8Array
-            nch = n.newHash as Uint8Array
-          }
-          children[idx] = ch
-          newChildren[idx] = nch
+
+          children[idx] = n.hash
+          newChildren[idx] = n.newHash
 
           pathIndices = pathIndices.concat(n.pathIndices)
           for (let i = 0; i < n.pathIndices.length; i++) {
             paths[n.pathIndices[i]].unshift(idx)
           }
         }
+        let h = hashBranch(children)
+        let nh = hashBranch(newChildren)
 
-        stack[stackTop++] = new StackItem(NodeType.Branch, pathIndices, null, children, null, newChildren)
+        stack[stackTop++] = new StackItem(NodeType.Branch, pathIndices, h, nh)
         break
     case Opcode.Extension:
         let nibblesLen = instructions[pc++]
@@ -311,41 +303,24 @@ function verifyMultiproofAndUpdate(
         }
         pc += nibblesLen
 
-        let n = stack[--stackTop]
-        let childHash: Uint8Array
-        let newChildHash: Uint8Array
-        if (n.kind == NodeType.Branch) {
-          childHash = hashBranch(n.sponge as Array<Uint8Array | null>)
-          newChildHash = hashBranch(n.newSponge as Array<Uint8Array | null>)
-        } else {
-          childHash = n.hash as Uint8Array
-          newChildHash = n.newHash as Uint8Array
-        }
-
         let key = nibbleArrToUintArr(addHexPrefix(nibbles, false))
         // addHexPrefix modifies array in-place
         nibbles = removeHexPrefix(nibbles)
-        let h = hashExtension(key, childHash)
-        let nh = hashExtension(key, newChildHash)
 
-        stack[stackTop++] = new StackItem(NodeType.Extension, n.pathIndices.slice(0), h, null, nh, null)
+        let n = stack[--stackTop]
+        let h = hashExtension(key, n.hash as Uint8Array)
+        let nh = hashExtension(key, n.newHash as Uint8Array)
+
+        stack[stackTop++] = new StackItem(NodeType.Extension, n.pathIndices.slice(0), h, nh)
         for (let i = 0; i < n.pathIndices.length; i++) {
           paths[n.pathIndices[i]] = nibbles.concat(paths[n.pathIndices[i]])
         }
         break
     }
   }
-
   let r = stack[stackTop - 1]
-  let rootHash: Uint8Array
-  let newRootHash: Uint8Array
-  if (r.kind == NodeType.Branch) {
-    rootHash = hashBranch(r.sponge as Array<Uint8Array | null>)
-    newRootHash = hashBranch(r.newSponge as Array<Uint8Array | null>)
-  } else {
-    rootHash = r.hash as Uint8Array
-    newRootHash = r.newHash as Uint8Array
-  }
+  let rootHash = r.hash as Uint8Array
+  let newRootHash = r.newHash as Uint8Array
 
   if (cmpBuf(rootHash, preStateRoot) != 0) {
     throw new Error('invalid root hash')

--- a/src/multiproof.ts
+++ b/src/multiproof.ts
@@ -18,7 +18,6 @@ export enum Opcode {
   Hasher = 1,
   Leaf = 2,
   Extension = 3,
-  Add = 4,
 }
 
 export enum NodeType {
@@ -75,25 +74,30 @@ export function verifyMultiproof(root: Buffer, proof: Multiproof, keys: Buffer[]
       // @ts-ignore
       paths[leafIdx - 1] = removeHexPrefix(stringToNibbles(l[0]))
     } else if (instr.kind === Opcode.Branch) {
-      const n = stack.pop()
-      if (!n) {
-        throw new Error('Stack underflow')
-      }
+      const branchIndices = instr.value as number[]
       const children = new Array(16).fill(null)
-      children[instr.value as number] = n
-
-      let nh = n.hash
-      if (n.kind === NodeType.Branch) {
-        nh = hashBranch(nh)
-      }
       const sponge = new Array(17).fill(Buffer.alloc(0))
-      sponge[instr.value as number] = nh
+      let pathIndices: number[] = []
+      for (const idx of branchIndices) {
+        const n = stack.pop()
+        if (!n) {
+          throw new Error('Stack underflow')
+        }
+        children[idx] = n
 
-      stack.push({ kind: NodeType.Branch, raw: children, pathIndices: n.pathIndices.slice(), hash: sponge })
+        let nh = n.hash
+        if (n.kind === NodeType.Branch) {
+          nh = hashBranch(nh)
+        }
 
-      for (let i = 0; i < n.pathIndices.length; i++) {
-        paths[n.pathIndices[i]] = [instr.value as number, ...paths[n.pathIndices[i]]]
+        sponge[idx] = nh
+        pathIndices = [...pathIndices, ...n.pathIndices]
+        for (const pi of n.pathIndices) {
+          paths[pi] = [idx, ...paths[pi]]
+        }
       }
+      const uniqPathIndices = Array.from(new Set(pathIndices))
+      stack.push({ kind: NodeType.Branch, raw: children, pathIndices: uniqPathIndices, hash: sponge })
     } else if (instr.kind === Opcode.Extension) {
       const n = stack.pop()
       if (!n) {
@@ -116,30 +120,6 @@ export function verifyMultiproof(root: Buffer, proof: Multiproof, keys: Buffer[]
       for (let i = 0; i < n.pathIndices.length; i++) {
         paths[n.pathIndices[i]] = [...(instr.value as number[]), ...paths[n.pathIndices[i]]]
       }
-    } else if (instr.kind === Opcode.Add) {
-      const n1 = stack.pop()
-      const n2 = stack.pop()
-      if (!n1 || !n2) {
-        throw new Error('Stack underflow')
-      }
-      assert(n2.kind === NodeType.Branch, 'expected branch node on stack')
-      assert((instr.value as number) < 17)
-      n2.raw[instr.value as number] = n1
-      n2.pathIndices = Array.from(new Set([...n1.pathIndices, ...n2.pathIndices]))
-
-      let nh = n1.hash
-      if (n1.kind === NodeType.Branch) {
-        nh = hashBranch(nh)
-      }
-      const sponge = n2.hash
-      assert(Array.isArray(sponge))
-      sponge[instr.value as number] = nh
-      n2.hash = sponge
-      stack.push(n2)
-
-      for (let i = 0; i < n1.pathIndices.length; i++) {
-        paths[n1.pathIndices[i]] = [instr.value as number, ...paths[n1.pathIndices[i]]]
-      }
     } else {
       throw new Error('Invalid opcode')
     }
@@ -148,7 +128,7 @@ export function verifyMultiproof(root: Buffer, proof: Multiproof, keys: Buffer[]
   // Assuming sorted keys
   for (let i = 0; i < paths.length; i++) {
     const addr = nibblesToBuffer(paths[i])
-    assert(addr.equals(keys[i]))
+    assert(addr.equals(keys[i]), `expected ${keys[i].toString('hex')} == ${addr.toString('hex')}`)
   }
 
   const r = stack.pop()
@@ -216,10 +196,11 @@ async function _makeMultiproof(trie: any, rootHash: any, keys: number[][]): Prom
       table[idx].push(k.slice(1))
     }
 
-    let addBranchOp = true
+    let branchIndices = []
     for (let i = 0; i < 16; i++) {
       if (table[i] === undefined) {
-        // Empty subtree, hash it and add a HASHER op
+        // None of the target keys are in this subtree.
+        // If non-empty hash it and add a HASHER op.
         const child = root.getValue(i)
         if (child) {
           proof.instructions.push({ kind: Opcode.Hasher })
@@ -232,12 +213,7 @@ async function _makeMultiproof(trie: any, rootHash: any, keys: number[][]): Prom
           } else {
             throw new Error('Invalid branch child')
           }
-          if (addBranchOp) {
-            proof.instructions.push({ kind: Opcode.Branch, value: i })
-            addBranchOp = false
-          } else {
-            proof.instructions.push({ kind: Opcode.Add, value: i })
-          }
+          branchIndices.push(i)
         }
       } else {
         const child = root.getValue(i) as Buffer
@@ -249,15 +225,11 @@ async function _makeMultiproof(trie: any, rootHash: any, keys: number[][]): Prom
         proof.hashes.push(...p.hashes)
         proof.keyvals.push(...p.keyvals)
         proof.instructions.push(...p.instructions)
-
-        if (addBranchOp) {
-          proof.instructions.push({ kind: Opcode.Branch, value: i })
-          addBranchOp = false
-        } else {
-          proof.instructions.push({ kind: Opcode.Add, value: i })
-        }
+        branchIndices.push(i)
       }
     }
+    branchIndices.reverse()
+    proof.instructions.push({ kind: Opcode.Branch, value: branchIndices })
   } else if (root.type === 'extention') {
     const extkey = root.key
     // Make sure all keys follow the extension node
@@ -331,8 +303,10 @@ export function flatEncodeInstructions(instructions: Instruction[]): Buffer {
   const res: number[] = []
   for (const instr of instructions) {
     res.push(instr.kind)
-    if (instr.kind === Opcode.Branch || instr.kind === Opcode.Add) {
-      res.push(instr.value as number)
+    if (instr.kind === Opcode.Branch) {
+      const indices = instr.value as number[]
+      res.push(indices.length)
+      res.push(...indices)
     } else if (instr.kind === Opcode.Extension) {
       const nibbles = instr.value as number[]
       res.push(nibbles.length)
@@ -349,7 +323,12 @@ export function flatDecodeInstructions(raw: Buffer): Instruction[] {
     const op = raw[i++]
     switch (op) {
       case Opcode.Branch:
-        res.push({ kind: Opcode.Branch, value: raw[i++] })
+        const ilength = raw.readUInt8(i++)
+        const indices = []
+        for (let j = 0; j < ilength; j++) {
+          indices.push(raw[i++])
+        }
+        res.push({ kind: Opcode.Branch, value: indices })
         break
       case Opcode.Hasher:
         res.push({ kind: Opcode.Hasher })
@@ -358,15 +337,12 @@ export function flatDecodeInstructions(raw: Buffer): Instruction[] {
         res.push({ kind: Opcode.Leaf })
         break
       case Opcode.Extension:
-        const length = raw.readUInt8(i++)
+        const nlength = raw.readUInt8(i++)
         const nibbles = []
-        for (let j = 0; j < length; j++) {
+        for (let j = 0; j < nlength; j++) {
           nibbles.push(raw[i++])
         }
         res.push({ kind: Opcode.Extension, value: nibbles })
-        break
-      case Opcode.Add:
-        res.push({ kind: Opcode.Add, value: raw[i++] })
         break
     }
   }
@@ -378,7 +354,8 @@ export function decodeInstructions(instructions: Buffer[][]) {
   for (const op of instructions) {
     switch (bufToU8(op[0])) {
       case Opcode.Branch:
-        res.push({ kind: Opcode.Branch, value: bufToU8(op[1]) })
+        // @ts-ignore
+        res.push({ kind: Opcode.Branch, value: op[1].map(v => bufToU8(v)) })
         break
       case Opcode.Hasher:
         res.push({ kind: Opcode.Hasher })
@@ -389,9 +366,6 @@ export function decodeInstructions(instructions: Buffer[][]) {
       case Opcode.Extension:
         // @ts-ignore
         res.push({ kind: Opcode.Extension, value: op[1].map(v => bufToU8(v)) })
-        break
-      case Opcode.Add:
-        res.push({ kind: Opcode.Add, value: bufToU8(op[1]) })
         break
     }
   }

--- a/test/multiproof.ts
+++ b/test/multiproof.ts
@@ -20,12 +20,11 @@ const SecureTrie = require('merkle-patricia-tree/secure')
 
 tape('decode and encode instructions', t => {
   t.test('rlp encoding', st => {
-    const raw = Buffer.from('d0c20201c20405c603c403030303c28006', 'hex')
+    const raw = Buffer.from('cdc102c603c403030303c380c106', 'hex')
     const expected = [
       { kind: Opcode.Leaf },
-      { kind: Opcode.Add, value: 5 },
       { kind: Opcode.Extension, value: [3, 3, 3, 3] },
-      { kind: Opcode.Branch, value: 6 },
+      { kind: Opcode.Branch, value: [6] },
     ]
     // @ts-ignore
     const res = decodeInstructions(rlp.decode(raw))
@@ -34,12 +33,11 @@ tape('decode and encode instructions', t => {
   })
 
   t.test('flat encoding', st => {
-    const raw = Buffer.from('0204050304030303030006', 'hex')
+    const raw = Buffer.from('02030403030303000106', 'hex')
     const instructions = [
       { kind: Opcode.Leaf },
-      { kind: Opcode.Add, value: 5 },
       { kind: Opcode.Extension, value: [3, 3, 3, 3] },
-      { kind: Opcode.Branch, value: 6 },
+      { kind: Opcode.Branch, value: [6] },
     ]
     const encoded = flatEncodeInstructions(instructions)
     st.assert(raw.equals(encoded))
@@ -70,7 +68,6 @@ tape('decode and encode multiproof', t => {
   })
 
   t.test('decode and encode two out of three leaves with extension', async st => {
-    console.log(Trie)
     const t = new Trie()
     const put = promisify(t.put.bind(t))
     const key1 = Buffer.from('1'.repeat(40), 'hex')
@@ -104,7 +101,7 @@ tape('multiproof tests', (t: tape.Test) => {
       { kind: Opcode.Hasher },
       { kind: Opcode.Branch, value: 1 },
       { kind: Opcode.Leaf },
-      { kind: Opcode.Add, value: 2 },
+      //{ kind: Opcode.Add, value: 2 },
     ]
     const proof = decodeMultiproof(raw)
     st.deepEqual(proof.instructions, expectedInstructions)
@@ -126,9 +123,9 @@ tape('multiproof tests', (t: tape.Test) => {
       { kind: Opcode.Leaf },
       { kind: Opcode.Branch, value: 1 },
       { kind: Opcode.Leaf },
-      { kind: Opcode.Add, value: 2 },
+      //{ kind: Opcode.Add, value: 2 },
       { kind: Opcode.Hasher },
-      { kind: Opcode.Add, value: 8 },
+      //{ kind: Opcode.Add, value: 8 },
     ]
     const proof = decodeMultiproof(raw)
     st.deepEqual(proof.instructions, expectedInstructions)
@@ -168,7 +165,7 @@ tape('make multiproof', t => {
     const proof = await makeMultiproof(t, [key1])
     st.equal(proof.hashes.length, 1)
     st.equal(proof.keyvals.length, 1)
-    st.equal(proof.instructions.length, 4)
+    st.equal(proof.instructions.length, 3)
     st.assert(verifyMultiproof(t.root, proof, [key1]))
     st.end()
   })


### PR DESCRIPTION
I think there's room for simplification in computing hashes after this change. The reason is that now by the end of executing the BRANCH opcode, we can already compute its hash and don't need to store its sponge on stack. I'll work on that now

Fixes #10