### PR TITLE
ci: run relayer and test ee with generated input

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,3 +18,6 @@
        - run:
            name: Run tests
            command: npm test
+       - run:
+           name: Run ee with generated input
+           command: npm run relayer && npm run ee


### PR DESCRIPTION
So far we've been running the TS unit tests in CI, but never the actual assembly EE code. This PR adds a new job to CI to generate a new yaml file via `npm run relayer` and then compile & run the EE with this new yaml file as input via `npm run ee`.