### PR TITLE
Add functions for evm code merkelization

### DIFF
--- a/src/relayer/lib.ts
+++ b/src/relayer/lib.ts
@@ -5,6 +5,7 @@ import { encode, decode } from 'rlp'
 import { Multiproof, verifyMultiproof, makeMultiproof, flatEncodeInstructions } from '../multiproof'
 import VM from 'ethereumjs-vm'
 import { Transaction } from 'ethereumjs-tx'
+import { getOpcodesForHF } from 'ethereumjs-vm/dist/evm/opcodes'
 
 const assert = require('assert')
 const { promisify } = require('util')
@@ -404,4 +405,66 @@ function rawMultiproof(proof: Multiproof, flatInstructions: boolean = false): an
       }),
     ]
   }
+}
+
+export function getBasicBlockIndices(code: Buffer): number[][] {
+  const TERMINATING_OPS = ['JUMP', 'JUMPI', 'STOP', 'RETURN', 'REVERT', 'SELFDESTRUCT']
+  const opcodes = getOpcodesForHF('istanbul')
+  const getOp = (i: number) => opcodes[code[i]] ? opcodes[code[i]].name : 'INVALID'
+
+  const blocks = [[0, -1]]
+  for (let i = 0; i < code.length; i++) {
+    let op = getOp(i)
+    // Skip push args
+    if (op === 'PUSH') {
+      i += code[i] - 0x5f
+    }
+
+    // Current instruction terminates block or next instruction is JUMPDEST
+    if (TERMINATING_OPS.includes(op) || (i + 1 < code.length && getOp(i + 1) === 'JUMPDEST')) {
+      blocks[blocks.length - 1][1] = i + 1
+      // Create new block if not at end of code
+      if (i + 1 < code.length) {
+        blocks.push([i + 1, -1])
+      }
+    }
+  }
+
+  // Close block if no terminating instruction at the end
+  if (blocks[blocks.length - 1][1] === undefined) {
+    blocks[blocks.length - 1][1] = code.length
+  }
+
+  return blocks
+}
+
+/**
+ * Does a single pass over bytecode to find the list
+ * of all basic blocks (i.e. blocks of code with no
+ * control flow change).
+ */
+export function getBasicBlocks(code: Buffer): Buffer[] {
+  const blocks = getBasicBlockIndices(code)
+  // Slice code based on block indices
+  return blocks.map((b: number[]) => code.slice(b[0], b[1]))
+}
+
+/**
+ * Divides code into basic blocks and constructs a MPT
+ * with these blocks as leaves. The key for each block is
+ * the index of the first byte of that block in the bytecode.
+ */
+export async function merkelizeCode(code: Buffer): Promise<any> {
+  const blockIndices = getBasicBlockIndices(code)
+  const trie = new Trie()
+  const putP = promisify(trie.put.bind(trie))
+  // Keys are indices into the bytecode. Determine key length by
+  // how large the last index is.
+  const keyLength = new BN(code.length - 1).byteLength()
+  for (let i = 0; i < blockIndices.length; i++) {
+    const key = new BN(blockIndices[i][0]).toBuffer('be', keyLength)
+    const val = code.slice(blockIndices[i][0], blockIndices[i][1])
+    await putP(key, val)
+  }
+  return trie
 }

--- a/src/relayer/lib.ts
+++ b/src/relayer/lib.ts
@@ -410,7 +410,7 @@ function rawMultiproof(proof: Multiproof, flatInstructions: boolean = false): an
 export function getBasicBlockIndices(code: Buffer): number[][] {
   const TERMINATING_OPS = ['JUMP', 'JUMPI', 'STOP', 'RETURN', 'REVERT', 'SELFDESTRUCT']
   const opcodes = getOpcodesForHF('istanbul')
-  const getOp = (i: number) => opcodes[code[i]] ? opcodes[code[i]].name : 'INVALID'
+  const getOp = (i: number) => (opcodes[code[i]] ? opcodes[code[i]].name : 'INVALID')
 
   const blocks = [[0, -1]]
   for (let i = 0; i < code.length; i++) {

--- a/src/relayer/lib.ts
+++ b/src/relayer/lib.ts
@@ -414,7 +414,7 @@ export function getBasicBlockIndices(code: Buffer): number[][] {
 
   const blocks = [[0, -1]]
   for (let i = 0; i < code.length; i++) {
-    let op = getOp(i)
+    const op = getOp(i)
     // Skip push args
     if (op === 'PUSH') {
       i += code[i] - 0x5f

--- a/src/relayer/lib.ts
+++ b/src/relayer/lib.ts
@@ -412,6 +412,7 @@ export function getBasicBlockIndices(code: Buffer): number[][] {
   const opcodes = getOpcodesForHF('istanbul')
   const getOp = (i: number) => (opcodes[code[i]] ? opcodes[code[i]].name : 'INVALID')
 
+  // [start, end) indices
   const blocks = [[0, -1]]
   for (let i = 0; i < code.length; i++) {
     const op = getOp(i)

--- a/test/relayer.ts
+++ b/test/relayer.ts
@@ -1,0 +1,40 @@
+import * as tape from 'tape'
+import { getBasicBlocks, getBasicBlockIndices, merkelizeCode } from '../src/relayer/lib'
+import { keccak256 } from 'ethereumjs-util'
+const { promisify } = require('util')
+const { prove, verifyProof } = require('merkle-patricia-tree/proof')
+const proveP = promisify(prove)
+const verifyProofP = promisify(verifyProof)
+
+tape('get evm basic blocks', async t => {
+  t.test('add11 bytecode, one block', (st: tape.Test) => {
+    const codeHex = '600160010160005500'
+    const code = Buffer.from(codeHex, 'hex')
+    const blocks = getBasicBlocks(code)
+    t.equal(blocks.length, 1, 'bytecode should have one block')
+    t.equal(blocks[0].toString('hex'), codeHex)
+    st.end()
+  })
+
+  t.test('two blocks separated by JUMPDEST', (st: tape.Test) => {
+    const code = Buffer.from('60005b600000', 'hex')
+    const blocks = getBasicBlocks(code)
+    t.equal(blocks.length, 2, 'bytecode should have two block')
+    t.equal(blocks[0].toString('hex'), '6000')
+    t.equal(blocks[1].toString('hex'), '5b600000')
+    st.end()
+  })
+})
+
+tape('merkelize evm bytecode', async t => {
+  t.test('merkelize basic code', async (st: tape.Test) => {
+    const code = Buffer.from('60005b600000', 'hex')
+    const blocks = getBasicBlockIndices(code)
+    const trie = await merkelizeCode(code)
+    const key = keccak256(Buffer.from('02', 'hex'))
+    const p = await proveP(trie, key)
+    const v = await verifyProofP(trie.root, key, p)
+    st.equal(v.toString('hex'), '5b600000')
+    st.end()
+  })
+})


### PR DESCRIPTION
Adds functions for dividing evm bytecode into basic blocks ([algorithm](https://github.com/ethereum/evmone/blob/3bab1de1ac5cb58aacc0bd6cc893737a1e216f2c/docs/efficient_gas_calculation_algorithm.md#basic-instruction-blocks)) and constructing a MPT with these blocks as leaves. The key of each block is the index of its first byte in the bytecode.

The functions are still not used anywhere. They'll have to be integrated into the EE at a later point when we have some more logic missing currently.

Fixes #37