### PR TITLE
Break after first unequal byte encountered in cmpBuf

### DIFF
--- a/assembly/__tests__/util.spec.ts
+++ b/assembly/__tests__/util.spec.ts
@@ -1,4 +1,4 @@
-import { stripBuf } from '../util'
+import { stripBuf, cmpBuf } from '../util'
 
 describe('stripBuf', () => {
   it('should strip buffer with preceding zeros', () => {
@@ -22,5 +22,51 @@ describe('stripBuf', () => {
     buf.fill(0)
     const res = stripBuf(buf)
     expect(res.length).toBe(0)
+  })
+})
+
+describe('cmpBuf', () => {
+  it('should return 1 for longer buffer', () => {
+    const buf = new Uint8Array(5)
+    buf.fill(1)
+    const other = new Uint8Array(4)
+    other.fill(1)
+    expect(cmpBuf(buf, other)).toBe(1)
+  })
+
+  it('should return -1 for shorter buffer', () => {
+    const buf = new Uint8Array(4)
+    buf.fill(1)
+    const other = new Uint8Array(5)
+    other.fill(1)
+    expect(cmpBuf(buf, other)).toBe(-1)
+  })
+
+  it('should return 0 for equal buffers', () => {
+    const buf = new Uint8Array(5)
+    buf.fill(1)
+    const other = new Uint8Array(5)
+    other.fill(1)
+    expect(cmpBuf(buf, other)).toBe(0)
+  })
+
+  it('should return 1 for greater buffers', () => {
+    const buf = new Uint8Array(5)
+    buf.fill(1)
+    buf[0] = 2
+    const other = new Uint8Array(5)
+    other.fill(2)
+    other[0] = 1
+    expect(cmpBuf(buf, other)).toBe(1)
+  })
+
+  it('should return -1 for lesser buffers', () => {
+    const buf = new Uint8Array(5)
+    buf.fill(2)
+    buf[0] = 1
+    const other = new Uint8Array(5)
+    other.fill(1)
+    other[0] = 2
+    expect(cmpBuf(buf, other)).toBe(-1)
   })
 })

--- a/assembly/util.ts
+++ b/assembly/util.ts
@@ -44,6 +44,8 @@ export function cmpBuf(buf: Uint8Array, other: Uint8Array): usize {
     } else {
       res = 1
     }
+    // Break after first un-equal byte encountered
+    break
   }
   return res
 }


### PR DESCRIPTION
Fixes #45, also add initial unit tests for `cmpBuf` which pass locally